### PR TITLE
Clarify in README how to get xml vs html output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,15 @@ With the command-line:
               [--outputencoding OUTPUTENCODING] [--xmldeclaration]
               [source]
 
+Notably, `-m xml` outputs XML (default) and `-m html` outputs HTML.
+
 With the python module
 
     >>> from html5tidy import tidy
     >>> tidy('some text')
     '<html><head/><body>some text</body></html>'
+    >>> tidy('some text', method='html')
+    '<html><head></head><body>some text</body></html>'
 
 
 Copyright


### PR DESCRIPTION
I was actually looking for a tool that outputs ["polyglot" markup](http://www.w3.org/TR/html-polyglot); "tidy html in the wild to well-formed xml/html" in your github desrciption gave me hope.

It took me some time to confirm your output is xml but not valid html, and then embarrasingly long to even notice there is a `-m html` option (which alas gives html but not valid xml).
I think having this in the README would be useful to other.
